### PR TITLE
Added preloader to get the model into memory after server start

### DIFF
--- a/src/main/java/com/agilewildcats/chattyCatty/controller/ChatController.java
+++ b/src/main/java/com/agilewildcats/chattyCatty/controller/ChatController.java
@@ -4,6 +4,8 @@ import com.agilewildcats.chattyCatty.service.prompt.PromptProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -19,6 +21,11 @@ public class ChatController {
 
     public ChatController(PromptProcessor promptProcessor) {
         this.promptProcessor = promptProcessor;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void doSomethingAfterStartup() {
+        ask("Tell me a joke");
     }
 
     @GetMapping("/general")


### PR DESCRIPTION
Simple fix to get ollama to load the selected model into memory - just ask it a question right after server start! This does slow down application layer start a bit, though.