### PR TITLE
Unit test fix

### DIFF
--- a/DEV-COMMANDS.md
+++ b/DEV-COMMANDS.md
@@ -153,6 +153,7 @@ Create a .env file in the top-level directory of the project.
    POSTGRES_PASSWORD=postgres
    SPRING_PROFILES_ACTIVE=dev
    OLLAMA_URL=http://host.docker.internal:11434
+   OLLAMA_MVNW_URL=http://localhost:11434
    ```
 Adjust these settings as needed for your environment.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is an application for serving AI responses to questions related to the Univ
   * Download the REST JSON API http://localhost:8080/v3/api-docs
   * Download as yaml file http://localhost:8080/v3/api-docs.yaml
 
-NOTE: Add documents into the `docs` folder for automatic ingestion into RAG.
+NOTE: Add documents into the `docs` folder for automatic ingestion (seeding) into RAG.
 
 ---
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,7 +11,7 @@ spring:
     init:
       mode: always
   ai:
-    postgresml:
+    postgresql:
       embedding:
         create-extension: true
         options:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,27 @@
+# These are the development environment settings for the project (test). Make settings changes
+# here that are useful while unit testing the project.
+
+# Set the logging level to DEBUG to get all messages
+logging:
+  level:
+    root: INFO
+
+spring:
+  sql:
+    init:
+      mode: always
+  ai:
+    postgresql:
+      embedding:
+        create-extension: true
+        options:
+          vector-type: pg_vector
+    vectorstore:
+      pgvector:
+        dimensions: 1024
+        initialize-schema: true
+    chat:
+      memory:
+        repository:
+          jdbc:
+            initialize-schema: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,11 +8,6 @@
 spring:
   application:
     name: "chattyCatty"
-  config:
-    import:
-      - optional:file:./myconfig.properties
-      - optional:file:./myconfig.yml
-      - optional:file:./.env
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVER}/${POSTGRES_INSTANCE}"
     username: "${POSTGRES_USER}"


### PR DESCRIPTION
Found a few issues in the coverage target for the makefile that blocked unit testing. Note there's yet another .env file change - add a line for the new `OLLAMA_MVNW_URL=http://localhost:11434` to get mvnw to see the ollama server outside of the context of docker. It will open the coverage web page if it works properly - tested as working on Windows Powershell (need verify on non-Windows).

To test this user story:
1. Switch to the branch using `git checkout unit-test-fix`
2. Add `OLLAMA_MVNW_URL=http://localhost:11434` to your .env file
3. Finally, execute `make run coverage` to show the tests working and Jococo report opens in the browser.

This will run the docker containers and then start the test execution and Jacoco coverage measurement, then open the report in your browser. 